### PR TITLE
Fix issues with demo setup

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -1,11 +1,11 @@
-version: "3"
+version: "3.8"
 services:
   mysql:
     image: mysql/mysql-server:8.0.27
     hostname: mysql
     container_name: mysql
     ports:
-      - 3306:3306
+      - "3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=debezium
       - MYSQL_USER=mysqluser
@@ -24,6 +24,10 @@ services:
       ZOO_MY_ID: 1
       ZOO_PORT: 2181
       ZOO_SERVERS: server.1=zookeeper:2888:3888;2181
+      ZOO_4LW_COMMANDS_WHITELIST: ruok
+    healthcheck:
+      test: echo "ruok" | nc localhost 2181 | grep -q "imok"
+      interval: 3s
   kafka:
     image: confluentinc/cp-kafka:latest
     hostname: kafka
@@ -39,15 +43,20 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_TOOLS_LOG4J_LOGLEVEL: ERROR
     depends_on:
-      [zookeeper]
-    healthcheck: {test: nc -z localhost 9092, interval: 1s}
+      zookeeper:
+        condition: service_healthy
+    healthcheck:
+      test: nc -z localhost 9092
+      interval: 3s
   orders-service:
     build: orders-service
     restart: unless-stopped
     container_name: orders-service
     depends_on:
-      - mysql
-      - kafka
+      mysql:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
     environment:
       - MYSQL_SERVER=mysql
       - KAFKA_BROKER_HOSTNAME=kafka

--- a/docker-compose-dashboard-enriched-quarkus.yml
+++ b/docker-compose-dashboard-enriched-quarkus.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 services:
   dashboard-enriched:
     build: streamlit
@@ -7,7 +7,8 @@ services:
     ports:
       - "8502:8501"
     depends_on:
-      - pinot-controller
+      pinot-controller:
+        condition: service_healthy
     volumes:
       - ./streamlit/app_enriched.py:/workdir/app.py
     environment:
@@ -23,4 +24,5 @@ services:
       - PRODUCTS_TOPIC=products
       - ENRICHED_ORDERS_TOPIC=enriched-order-items
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy

--- a/docker-compose-dashboard.yml
+++ b/docker-compose-dashboard.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 services:
   dashboard:
     build: streamlit

--- a/docker-compose-pinot.yml
+++ b/docker-compose-pinot.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.8"
 services:
   pinot-controller:
     image: apachepinot/pinot:0.12.0
@@ -7,9 +7,12 @@ services:
     restart: unless-stopped
     ports:
       - "9000:9000"
+    healthcheck:
+      test: wget -q -O - localhost:9000/health | grep "OK"
+      interval: 3s
     depends_on:
-      - zookeeper
-    healthcheck: {test: nc -z localhost 9000, interval: 1s}
+      zookeeper:
+        condition: service_healthy
   pinot-broker:
     image: apachepinot/pinot:0.12.0
     command: "StartBroker -zkAddress zookeeper:2181"
@@ -17,15 +20,20 @@ services:
     container_name: "pinot-broker"
     ports:
       - "8099:8099"
+    healthcheck:
+      test: wget -q -O - localhost:8099/health | grep "OK"
+      interval: 3s
     depends_on:
-      - pinot-controller
+      pinot-controller:
+        condition: service_healthy
   pinot-server:
     image: apachepinot/pinot:0.12.0
     container_name: "pinot-server"
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     depends_on:
-      - pinot-broker
+      pinot-broker:
+        condition: service_healthy
   pinot-add-table:
     image: apachepinot/pinot:0.12.0
     container_name: "pinot-add-table"
@@ -38,4 +46,5 @@ services:
     environment:
     - "JAVA_OPTS=-Dpinot.admin.system.exit=true"
     depends_on:
-      - pinot-controller
+      pinot-controller:
+        condition: service_healthy

--- a/kafka-streams-quarkus/Dockerfile
+++ b/kafka-streams-quarkus/Dockerfile
@@ -3,36 +3,4 @@ COPY src /usr/src/app/src
 COPY pom.xml /usr/src/app
 RUN mvn -f /usr/src/app/pom.xml clean package
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
-
-ARG JAVA_PACKAGE=java-11-openjdk-headless
-ARG RUN_JAVA_VERSION=1.3.5
-
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
-
-# Install java and the run-java script
-# Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
-    && microdnf update \
-    && microdnf clean all \
-    && mkdir /deployments \
-    && chown 1001 /deployments \
-    && chmod "g+rwX" /deployments \
-    && chown 1001:root /deployments \
-    && curl https://repo1.maven.org/maven2/io/fabric8/run-java-sh/${RUN_JAVA_VERSION}/run-java-sh-${RUN_JAVA_VERSION}-sh.sh -o /deployments/run-java.sh \
-    && chown 1001 /deployments/run-java.sh \
-    && chmod 540 /deployments/run-java.sh \
-    && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
-
-# Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
-
-COPY --from=build /usr/src/app/target/quarkus-app/lib/ /deployments/lib/
-COPY --from=build /usr/src/app/target/quarkus-app/*.jar /deployments/
-COPY --from=build /usr/src/app/target/quarkus-app/app/ /deployments/app/
-COPY --from=build /usr/src/app/target/quarkus-app/quarkus/ /deployments/quarkus/
-
-EXPOSE 8080
-USER 1001
-
-ENTRYPOINT [ "/deployments/run-java.sh" ]
+CMD ["java", "-Dquarkus.http.host=0.0.0.0", "-cp", ".", "-jar", "/usr/src/app/target/quarkus-app/quarkus-run.jar"]

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -2,3 +2,4 @@ streamlit==1.12.0
 plotly==5.10.0
 pinotdb==0.4.5
 ipywidgets==8.0.2
+altair<5


### PR DESCRIPTION
1. There is an incompatible breaking change in one of the dependencies of streamlit. Pin it to avoid import/module errors so that the dashboard can start up.
2. pinot image doesn't have `nc` command used for the healthchecks so those always failed. Replace those with using wget to query pinot `/health` endpoints.
3. `depends_on` by default does not wait for the dependencies to be healthy but just to be started. Use `service_healthy` to ensure container is started only after dependencies are ready.
4. The zookeeper healthcheck using `nc` can be insufficient in some cases. In particular, I noticed hangs with pinot waiting for zookeeper while it  was up but not ready to accept connections. The ruok/imok command is a better test.
5. When run with the /deployments/run-java.sh script in the ubi-minimal image, the container exits mysteriously without no visible error. I have been unable to debug the cause of it so far but running the jar directly with java seems to work fine. **This is  not the right way to fix it but works for now.**